### PR TITLE
Add `.npmrc` file that is needed to bypass OTP

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
As we enabled OTP in our npm account, we need `.npmrc` (+ the automation token set on CI).
This PR adds the the file.

See the details here:
https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow#create-and-check-in-a-project-specific-npmrc-file